### PR TITLE
update light position from its world position on every render

### DIFF
--- a/src/illumPass.ts
+++ b/src/illumPass.ts
@@ -73,6 +73,7 @@ export class GodraysIllumPass extends Pass implements Resizable {
   private shadowMapSet = false;
   private props: GodraysIllumPassProps;
   private lastParams: GodraysPassParams;
+  private lightWorldPos = new THREE.Vector3();
 
   constructor(props: GodraysIllumPassProps, params: GodraysPassParams) {
     super('GodraysPass');
@@ -104,7 +105,7 @@ export class GodraysIllumPass extends Pass implements Resizable {
       this.updateUniforms(this.props, this.lastParams);
       this.shadowMapSet = true;
     }
-
+    this._updateLightPosition(this.props);
     renderer.setRenderTarget(outputBuffer);
     renderer.render(this.scene, this.camera);
   }
@@ -119,6 +120,10 @@ export class GodraysIllumPass extends Pass implements Resizable {
     }
   }
 
+  private _updateLightPosition({light, camera}: GodraysIllumPassProps) {
+		light.getWorldPosition(this.lightWorldPos);
+	}
+
   public updateUniforms({ light, camera }: GodraysIllumPassProps, params: GodraysPassParams): void {
     const shadow = light.shadow;
     if (!shadow) {
@@ -131,7 +136,7 @@ export class GodraysIllumPass extends Pass implements Resizable {
     const uniforms = this.material.uniforms;
     uniforms.density.value = params.density;
     uniforms.maxDensity.value = params.maxDensity;
-    uniforms.lightPos.value = light.position;
+    uniforms.lightPos.value = this.lightWorldPos;
     uniforms.cameraPos.value = camera.position;
     uniforms.lightCameraProjectionMatrix.value = light.shadow.camera.projectionMatrix;
     uniforms.lightCameraMatrixWorldInverse.value = light.shadow.camera.matrixWorldInverse;


### PR DESCRIPTION
this allows the light's position to be animated when under a transformed parent, or those parent's transform to be animated.

One thing I have tried but could not make it work is to completely regenerate the uniforms when a new light is given. When I try to set `GodraysIllumPass.shadowMapSet` to false so that `updateUniforms` is called again, I end up with a much brighter render. Not sure if I'll be able to investigate further, but it would be amazing if there was an api like `GodraysPass.setLight` which took care of regenerating what needs to be.