### PR TITLE
Preserve scene alpha channel in godrays composite

### DIFF
--- a/src/compositor.frag
+++ b/src/compositor.frag
@@ -83,7 +83,7 @@ void main() {
 
   float bestChoice = totalWeight > 0.0 ? totalIllum / totalWeight : 0.0;
 
-  vec3 diffuse = texture2D(sceneDiffuse, vUv).rgb;
+  vec4 diffuse = texture2D(sceneDiffuse, vUv);
 
   #if defined(DEBUG_STEPS)
   // In debug mode, the godrays texture contains heatmap RGB — pass through directly
@@ -103,9 +103,9 @@ void main() {
       totalColor += data.rgb * w;
     }
   }
-  gl_FragColor = vec4(totalColorWeight > 0.0 ? totalColor / totalColorWeight : vec3(0.0), 1.0);
+  gl_FragColor = vec4(totalColorWeight > 0.0 ? totalColor / totalColorWeight : vec3(0.0), diffuse.a);
   #else
-  gl_FragColor = vec4(mix(diffuse, color, bestChoice), 1.0);
+  gl_FragColor = vec4(mix(diffuse.rgb, color, bestChoice), diffuse.a);
   #endif
 
   #include <dithering_fragment>


### PR DESCRIPTION
I'm using three-good-godrays in my project. I have a MeshLambertMaterial set with THREE.NoBlending, opacity: 0, and transparent: true — this is intended to write transparent pixels to the color buffer, effectively "cutting a hole" in the WebGL canvas so that a CSS3DObject (rendered on a separate DOM layer) can show through.

This works correctly without the godrays pass. But after adding GodraysPass with renderToScreen = true, the hole becomes solid black instead of transparent.

Below are two images showing the code before and after the changes. Please note a guide screen located slightly to the right of the center in the images — it is very small. It is an iframe embedding a web page, implemented through THREE.NoBlending to create a cutout/hole effect.

before:
<img width="3840" height="1822" alt="image" src="https://github.com/user-attachments/assets/05192842-cb23-4246-8c47-930059b6ce0a" />

after:
<img width="3840" height="1822" alt="image" src="https://github.com/user-attachments/assets/990caf2b-7457-42c5-8585-6fa2c9b7f036" />
