### PR TITLE
Support both log depth buffer defines across three.js versions

### DIFF
--- a/src/compositor.frag
+++ b/src/compositor.frag
@@ -27,7 +27,8 @@ varying vec2 vUv;
 #include <dithering_pars_fragment>
 
 float linearize_depth(float depth, float zNear, float zFar) {
-  #if defined( USE_LOGDEPTHBUF )
+  // three.js renamed USE_LOGDEPTHBUF to USE_LOGARITHMIC_DEPTH_BUFFER in r180
+  #if defined( USE_LOGDEPTHBUF ) || defined( USE_LOGARITHMIC_DEPTH_BUFFER )
   float d = pow(2.0, depth * log2(far + 1.0)) - 1.0;
   float a = far / (far - near);
   float b = far * near / (near - far);

--- a/src/godrays.frag
+++ b/src/godrays.frag
@@ -39,7 +39,8 @@ uniform mat4 premultipliedLightCameraMatrix;
 #include <packing>
 
 float linearize_depth(float depth, float zNear, float zFar) {
-  #if defined( USE_LOGDEPTHBUF )
+  // three.js renamed USE_LOGDEPTHBUF to USE_LOGARITHMIC_DEPTH_BUFFER in r180
+  #if defined( USE_LOGDEPTHBUF ) || defined( USE_LOGARITHMIC_DEPTH_BUFFER )
   float d = pow(2.0, depth * log2(zFar + 1.0)) - 1.0;
   float a = zFar / (zFar - zNear);
   float b = zFar * zNear / (zNear - zFar);
@@ -50,7 +51,8 @@ float linearize_depth(float depth, float zNear, float zFar) {
 }
 
 vec3 WorldPosFromDepth(float depth) {
-  #if defined( USE_LOGDEPTHBUF )
+  // three.js renamed USE_LOGDEPTHBUF to USE_LOGARITHMIC_DEPTH_BUFFER in r180
+  #if defined( USE_LOGDEPTHBUF ) || defined( USE_LOGARITHMIC_DEPTH_BUFFER )
   float d = pow(2.0, depth * log2(far + 1.0)) - 1.0;
   float a = far / (far - near);
   float b = far * near / (near - far);


### PR DESCRIPTION
Three.js renamed the USE_LOGDEPTHBUF shader define to USE_LOGARITHMIC_DEPTH_BUFFER in r180. Since this library's peer dependency range spans both sides of that change (>= 0.125.0 <= 0.182.0), the log-depth un-linearization in the shaders silently stopped working on r180+.

This PR makes the depth-unlinearization checks in godrays.frag and compositor.frag accept both macro names:
`#if defined( USE_LOGDEPTHBUF ) || defined( USE_LOGARITHMIC_DEPTH_BUFFER )`
